### PR TITLE
wifi: Allow configuration of country code for wifi

### DIFF
--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -266,4 +266,34 @@
         <item>600000</item>
     </string-array>
 
+    <!-- Wi-Fi settings. Presented as a list dialog to the user to choose the Wi-Fi region code. -->
+    <string-array name="wifi_countrycode_entries">
+        <item>United States</item>
+        <item>Canada, Taiwan</item>
+        <item>Germany</item>
+        <item>Europe</item>
+        <item>Japan, Russia</item>
+        <item>Australia</item>
+        <item>China</item>
+        <item>Korea</item>
+        <item>South Africa, Turkey</item>
+        <item>Israel, Singapore</item>
+        <item>Brazil</item>
+        <item>India</item>
+    </string-array>
+
+    <string-array name="wifi_countrycode_values" translatable="false">
+        <item>US</item>
+        <item>CA</item>
+        <item>DE</item>
+        <item>GB</item>
+        <item>JP</item>
+        <item>AU</item>
+        <item>CN</item>
+        <item>KR</item>
+        <item>TR</item>
+        <item>SG</item>
+        <item>BR</item>
+        <item>IN</item>
+    </string-array>
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -409,6 +409,13 @@
     <string name="hotstpot_inactivity_timeout_never_summary_text">Portable Wi\u2011Fi hotspot will never timeout</string>
     <string name="hotstpot_inactivity_timeout_summary_text">Portable Wi\u2011Fi hotspot will timeout after <xliff:g id="timeout">%1$s</xliff:g></string>
 
+    <!-- Wi-Fi region code -->
+    <string name="wifi_setting_countrycode_title">Wi\u2011Fi region code</string>
+    <!-- Wi-Fi settings screen, setting summary for setting the wifi frequency band [CHAR LIMIT=50]-->
+    <string name="wifi_setting_countrycode_summary">Specify the region code for Wi\u2011Fi</string>
+    <!-- Wi-Fi settings screen, error message when the frequency band could not be set [CHAR LIMIT=50]. -->
+    <string name="wifi_setting_countrycode_error">There was a problem setting the region code.</string>
+
     <!-- Wake on plug -->
     <string name="wake_when_plugged_or_unplugged_title">Wake on plug</string>
     <string name="wake_when_plugged_or_unplugged_summary">Turn the screen on when connecting or disconnecting a power source</string>

--- a/res/xml/wifi_advanced_settings.xml
+++ b/res/xml/wifi_advanced_settings.xml
@@ -58,6 +58,14 @@
             android:summary="@string/notify_connect_summary"
             android:persistent="false"/>
 
+    <ListPreference
+            android:key="wifi_countrycode"
+            android:title="@string/wifi_setting_countrycode_title"
+            android:summary="@string/wifi_setting_countrycode_summary"
+            android:persistent="false"
+            android:entries="@array/wifi_countrycode_entries"
+            android:entryValues="@array/wifi_countrycode_values" />
+
     <Preference
             android:key="install_credentials"
             android:title="@string/wifi_install_credentials"


### PR DESCRIPTION
Wifi country code handling is a nightmare - Most retail devices
have region customization in /system for each country a device
is shipped to.

This doesn't work very well for a firmware like Cyanogenmod,
where we try to support all target countries with one firmware
package.  For whatever reason, with newer Broadcom drivers/
firmware blobs, the old trick of using a universal region code
(ccode=ALL in nvram_net.txt) does not seem to work.  Who knows
what the deal is for other wifi chipsets.

The good thing is that wpa_supplicant has a standardized
cross-chipset method for setting the region code, and we
use that here.

Cherry-Pick: https://review.cyanogenmod.org/#/c/119667/

JIRA: CML-118

Change-Id: Ia9f5133f61f56d89ccb290e37a393f5de507e1cf