### PR TITLE
Squash commit of SAR and IC Code.

### DIFF
--- a/res/layout/regulatory_info.xml
+++ b/res/layout/regulatory_info.xml
@@ -13,15 +13,34 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+    <TextView
+        android:id="@+id/sarValues"
+        android:textColor="@color/regulatory_text_color"
+        android:textSize="16sp"
+        android:padding="5dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+    <TextView
+        android:id="@+id/icCodes"
+        android:textColor="@color/regulatory_text_color"
+        android:textSize="16sp"
+        android:padding="5dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
     <ImageView
         android:id="@+id/regulatoryInfo"
         android:adjustViewBounds="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:scaleType="centerCrop"
-        android:src="@drawable/regulatory_info" />
-</ScrollView>
+        android:src="@drawable/regulatory_info"
+        android:visibility="gone"/>
+</LinearLayout>
 

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -485,4 +485,15 @@
     <string name="sub_activate_failed">Activation failed.</string>
     <string name="sub_deactivate_success">SIM deactivated.</string>
     <string name="sub_deactivate_failed">Deactivation failed.</string>
+
+    <!-- About phone settings screen, setting option dialog title to show regulatory information [CHAR LIMIT=25] -->
+    <string name="regulatory_information_dialog_title">@string/regulatory_labels</string>
+
+    <!-- SAR information -->
+    <string name="maximum_head_level">Head: %1$s W/kg</string>
+    <string name="maximum_body_level">Body: %1$s W/kg</string>
+
+    <!-- IC Codes -->
+    <string name="ic_code_model">Model: %1$s</string>
+    <string name="ic_code_full">IC: %1$s</string>
 </resources>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -73,6 +73,7 @@
 
     <color name="wifi_divider">#ffe0e0e0</color>
     <color name="sim_noitification">@*android:color/material_deep_teal_500</color>
+    <color name="regulatory_text_color">#000</color>
 
     <color name="confirm_device_credential_transparent_black">#60000000</color>
     <color name="fab_ripple">#1fffffff</color><!-- 12% white -->

--- a/res/values/config.xml
+++ b/res/values/config.xml
@@ -110,4 +110,19 @@
     <!-- Does the device allow for manual subscription provisioning? Only works for multi-sim devices,
          and currently depends on QC's proprietary telephony stack -->
     <bool name="config_enableManualSubProvisioning">true</bool>
+
+    <!-- SAR Level for a device -->
+    <!-- Must be overlaid by device -->
+    <bool name="config_show_sar_enable" translatable="false">false</bool>
+    <!-- Maximum Specific Absorption Rate for head -->
+    <string name="sar_head_level" translatable="false"></string>
+    <!-- Maximum Specific Absorption Rate for body -->
+    <string name="sar_body_level" translatable="false"></string>
+
+    <!-- IC Code for a device -->
+    <!-- Must be overlaid by device -->
+    <bool name="config_show_ic_enable" translatable="false">false</bool>
+    <!-- IC Code -->
+    <string name="ic_code" translatable="false"></string>
+    <string name="ic_model" translatable="false"></string>
 </resources>

--- a/src/com/android/settings/RegulatoryInfoDisplayActivity.java
+++ b/src/com/android/settings/RegulatoryInfoDisplayActivity.java
@@ -25,9 +25,12 @@ import android.os.Bundle;
 import android.os.SystemProperties;
 import android.text.TextUtils;
 import android.view.Gravity;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import com.android.settings.deviceinfo.Status;
 
 /**
  * {@link Activity} that displays regulatory information for the "Regulatory information"
@@ -56,8 +59,10 @@ public class RegulatoryInfoDisplayActivity extends Activity implements
         }
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this)
-                .setTitle(R.string.regulatory_labels)
+                .setTitle(R.string.regulatory_information_dialog_title)
                 .setOnDismissListener(this);
+
+        View view = getLayoutInflater().inflate(R.layout.regulatory_info, null);
 
         boolean regulatoryInfoDrawableExists = false;
         int resId = getResourceId();
@@ -73,24 +78,29 @@ public class RegulatoryInfoDisplayActivity extends Activity implements
             }
         }
 
-        CharSequence regulatoryText = resources.getText(R.string.regulatory_info_text);
-
         if (regulatoryInfoDrawableExists) {
-            View view = getLayoutInflater().inflate(R.layout.regulatory_info, null);
             ImageView image = (ImageView) view.findViewById(R.id.regulatoryInfo);
+            image.setVisibility(View.VISIBLE);
             image.setImageResource(resId);
-            builder.setView(view);
-            builder.show();
-        } else if (regulatoryText.length() > 0) {
-            builder.setMessage(regulatoryText);
-            AlertDialog dialog = builder.show();
-            // we have to show the dialog first, or the setGravity() call will throw a NPE
-            TextView messageText = (TextView) dialog.findViewById(android.R.id.message);
-            messageText.setGravity(Gravity.CENTER);
-        } else {
-            // neither drawable nor text resource exists, finish activity
-            finish();
         }
+
+        String sarValues = Status.getSarValues(getResources());
+        TextView sarText = (TextView) view.findViewById(R.id.sarValues);
+        if (!TextUtils.isEmpty(sarValues)) {
+            sarText.setVisibility(resources.getBoolean(R.bool.config_show_sar_enable)
+                    ? View.VISIBLE : View.GONE);
+            sarText.setText(sarValues);
+        }
+
+        String icCodes = Status.getIcCodes(getResources());
+        TextView icCode = (TextView) view.findViewById(R.id.icCodes);
+        if (!TextUtils.isEmpty(icCodes)) {
+            icCode.setVisibility(resources.getBoolean(R.bool.config_show_ic_enable)
+                    ? View.VISIBLE : View.GONE);
+            icCode.setText(icCodes);
+        }
+        builder.setView(view);
+        builder.show();
     }
 
     private int getResourceId() {

--- a/src/com/android/settings/deviceinfo/Status.java
+++ b/src/com/android/settings/deviceinfo/Status.java
@@ -391,4 +391,20 @@ public class Status extends SettingsPreferenceFragment {
             return Build.SERIAL;
         }
     }
+
+    public static String getSarValues(Resources res) {
+        String headLevel = String.format(res.getString(R.string.maximum_head_level,
+                res.getString(R.string.sar_head_level)));
+        String bodyLevel = String.format(res.getString(R.string.maximum_body_level,
+                res.getString(R.string.sar_body_level)));
+        return headLevel + "\n" + bodyLevel;
+    }
+
+    public static String getIcCodes(Resources resources) {
+        String model = String.format(resources.getString(R.string.ic_code_model,
+                Build.MODEL));
+        String icCode = String.format(resources.getString(R.string.ic_code_full,
+                resources.getString(R.string.ic_code)));
+        return model + "\n" + icCode;
+    }
 }


### PR DESCRIPTION
TICKET: CYNGNOS-1586

Settings: Show SAR on Regulatory Info (from CM11)

This brings these three commits from CM11:

Settings: Create SAR level preference, allow overlay.
Change-Id: I1af616696702f72b8a6276b3b01e940d61735137

Change Regulatory Info Activity to prefer string over image
Change-Id: I9ea5c2bf469af8f654ec4e4bb4f2a8a5738e6a95

Settings: Allow Regulator Information Dialog Title to be overlaid.
Change-Id: I5aead313589f5d5291d20a0388d2d8bc7242b711

Settings: Refactory regulatory dialog. Display IC Code.

Change-Id: Id268830404d09eed318e38474fe1a9062fc4e962