### PR TITLE
Settings: handle decrypting larger pattern sizes for sw600dp

### DIFF
--- a/res/layout-sw600dp/crypt_keeper_pattern_entry.xml
+++ b/res/layout-sw600dp/crypt_keeper_pattern_entry.xml
@@ -36,6 +36,17 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/pattern_sizes"
+        android:layout_width="@dimen/crypt_keeper_pattern_size"
+        android:layout_height="@dimen/crypt_keeper_pattern_size"
+        android:orientation="horizontal"
+        android:layout_gravity="center_horizontal">
+
+        <include layout="@layout/crypt_keeper_pattern_sizes" />
+
+    </LinearLayout>
+
     <include layout="@layout/crypt_keeper_emergency_button" />
 
 </LinearLayout>


### PR DESCRIPTION
* Apply bc86445070a5ea526242d8e4e4389d7824a75fd4 to layout-sw600dp
  in order to fix decryption with pattern larger than 3x3 on tablets

BUGBASH-671

Change-Id: Ic831adc73b7ab942c2f9b5bc65844b8f3c9f6f2d