### PR TITLE
DO NOT MERGE. ActivityPicker shouldn't grant permissions.

### DIFF
--- a/src/com/android/settings/ActivityPicker.java
+++ b/src/com/android/settings/ActivityPicker.java
@@ -78,6 +78,10 @@ public class ActivityPicker extends AlertActivity implements
         Parcelable parcel = intent.getParcelableExtra(Intent.EXTRA_INTENT);
         if (parcel instanceof Intent) {
             mBaseIntent = (Intent) parcel;
+            mBaseIntent.setFlags(mBaseIntent.getFlags() & ~(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                    | Intent.FLAG_GRANT_PREFIX_URI_PERMISSION));
         } else {
             mBaseIntent = new Intent(Intent.ACTION_MAIN, null);
             mBaseIntent.addCategory(Intent.CATEGORY_DEFAULT);


### PR DESCRIPTION
This picker has no business granting any Uri permissions, so remove
any grant flags that malicious apps may have tried sneaking in.

Test: builds, boots
Bug: 32879772
Change-Id: I91c48c73287a271bd6c99e60e216dead22e68764
(cherry picked from commit 3f218e8431cb5648bcb46131551c133ba53ef870)
(cherry picked from commit b5e93969a5e0c3a3f07e068dbc763cdd995a0e21)