### PR TITLE
FingerprintEnrollFindSensor: Don't overlay front for side sensors

### DIFF
--- a/src/com/android/settings/fingerprint/FingerprintEnrollFindSensor.java
+++ b/src/com/android/settings/fingerprint/FingerprintEnrollFindSensor.java
@@ -74,7 +74,7 @@ public class FingerprintEnrollFindSensor extends FingerprintEnrollBase {
         message.setText(getString(
                 R.string.security_settings_fingerprint_enroll_find_sensor_message_cm,
                 location));
-        if (sensorLocation != SENSOR_LOCATION_BACK) {
+        if (sensorLocation == SENSOR_LOCATION_FRONT) {
             findViewById(R.id.fingerprint_sensor_location_front_overlay)
                     .setVisibility(View.VISIBLE);
         }


### PR DESCRIPTION
* Both the base image and the base image + overlay are equally nonsense
  for devices with a side fingerprint scanner, but for those that overlay
  a custom fingerprint enrollment graphic, this image overlay wreaks havoc
* Only set this overlay to be visible if the sensor is on the front, to
  allow devices with side sensors to only overlay the base image

Change-Id: I7cbcea4830d4526cf9f7d139e7f84f21117fa9c4